### PR TITLE
Scope section replacement

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,27 +185,43 @@
 
 
       		<section id="scope" class="scope">
-        		<h2>Scope</h2>
+				<h2>Scope</h2>
+				
 				<p>
-					EPUB is a distribution and interchange format for digital publications and documents. The EPUB format provides a means of representing, packaging, and encoding structured and semantically enhanced Web content—including HTML, CSS, SVG and other resources—for distribution in a single-file container. 
+					EPUB is a distribution and interchange format for digital publications and documents that has been in global use by publishers and vendors for over a decade. The latest version of EPUB, <a href='https://www.w3.org/publishing/epub32/epub-spec.html'>EPUB 3.2</a>, has been published by the <a href='https://www.w3.org/community/epub3/'>W3C EPUB 3 Community Group</a> as a Final Specification. EPUB 3 is strongly related to, and reliant upon, W3C specifications: it provides a means of representing, packaging, and encoding structured and semantically enhanced Web content—including <a href="https://html.spec.whatwg.org/multipage/">HTML</a>, <a href="https://www.w3.org/Style/CSS/specs.en.html">CSS</a>, <a href="https://www.w3.org/TR/SVG11/">SVG</a href="https://www.w3.org/TR/SVG11/">, <a href="https://www.w3.org/TR/MathML/">MathML</a> and other resources—for distribution in a single–file container. The EPUB 3 Working Group will advance, refine, and clarify the standard to ensure its relevance as digital publishing continues to evolve.
+				</p>
 
+				<p>
+					The scope of the EPUB 3 Working Group includes the following:
+				</p>
+				
+				<ul>
+					<li>
+						Improvements and clarifications related to reading system conformance.
+					</li>
+					<li>
+						Development of a test suite to check reading system conformance.
+					</li>
+					<li>
+						Clarifications to the current use of open Web technologies, such as supported JavaScript APIs and CSS modules.
+					</li>
+					<li>
+						Enhancements and improvements to internationalization of EPUB-defined technologies to ensure global usability. While the content of a digital publication (HTML, CSS, etc.) already have advanced internationalization features, an EPUB 3 publication also has specific textual content like metadata, table of contents, etc., which must abide to all requirements of internationalization. 
+					</li>
+					<li>
+						Integration of new open web platform technologies necessary for enhanced digital publishing experiences, including HTML5 for content documents and new core media types for content.
+					</li>
+					<li>
+						Continued integration of errata and bug fixes.
+					</li>
+				</ul>
+
+				<p>
+					EPUB 3.X will endeavor to remain compatible with existing content. Any EPUB 3.2 publication should be valid under any new version of EPUB published by this Working Group, unless it relies on features that are subject to errata on EPUB 3.2. In particular all EPUB 3 specifications defined by this Working Group will use <code style="color:black">version=”3.0”</code> for the package file, to ensure compatibility with previous versions of EPUB 3.
 				</p>	
 
 				<p>
-					EPUB 3 is a direct descendant of the original <a href="http://web.archive.org/web/20101212174917/http://idpf.org/oebps/oebps1.0/index.htm">OEB 1.0</a> from 1999, using an XML package file for structural and bibliographic metadata, packaged using <a href="https://www.w3.org/publishing/epub3/epub-ocf.html">OCF</a>. EPUB 3 is strongly related to, and reliant upon, W3C specifications: all the relevant content within a digital publication are defined in <a href="https://html.spec.whatwg.org/multipage/">HTML</a>, <a href="https://www.w3.org/Style/CSS/specs.en.html">CSS</a>, <a href="https://www.w3.org/TR/SVG11/">SVG</a href="https://www.w3.org/TR/SVG11/">, <a href="https://www.w3.org/TR/MathML/">MathML</a>, etc. The EPUB 3 format provides a method to include metadata within the package, as well as a packaging format. These features align with the current distribution model of the digital publishing market. The latest version of EPUB 3 was published as a W3C Final Community Group Specification as <a href="https://www.w3.org/publishing/epub32/epub-overview.html">EPUB 3.2</a> and is already largely used by the industry. The work defined by this charter relies on that version of EPUB 3.  
-
-				</p>					
-				
-				<p>
-					Following the work that went into EPUB 3.2 to simplify the specification, there is more to be done, particularly in addressing issues with user agent conformance. The next version of EPUB will be easier to understand and use, and should allow for more types of publications. During the development of the next version of EPUB 3, there will be a strong emphasis on enhancing reading system conformance across the board via rigorous testing of the specifications and providing a comprehensive test suite that reading system implementers may also use. As part of its activity the Working Group will also ensure an even stronger alignment with relevant W3C specifications in terms of the content that a digital publication relies on.
-				</p>					
-				
-				<p>
-					EPUB 3.X will endeavor to remain compatible with existing content. Any EPUB 3.2 publication should be valid under any new version of EPUB published by this Working Group, unless it relies on features that are subject to errata on EPUB 3.2. In particular all EPUB 3 specifications defined by this Working Group will use <code style="color:black">version=”3.0”</code> for the package file, to ensure compatibility with previous versions of EPUB 3.
-				</p>					
-				
-				<p>
-					There should be thorough review of internationalization issues. While the content of a digital publication is in HTML, SVG, etc., which already have advanced internationalization features, an EPUB 3 publication also has EPUB 3 specific textual content like metadata, table of contents, etc., which must also abide to all requirements of internationalization. 
+					The Working Group will also work with other groups, as appropriate, in the development of standards for digital publishing (e.g., an update to the <a href='https://www.w3.org/TR/dpub-aria-1.0/'>Digital Publishing WAI-ARIA Module</a>).
 				</p>					
 
 				<section id="section-out-of-scope">


### PR DESCRIPTION
This alternative to the scope section comes from @mattgarrish in a private communication. It makes the scope section crisper and more straight to the point.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Invalid URI "https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fepub-3-wg-charter%2F6d0adbd1813d84c8960d8a80bbf1db4dd33b4265%2Findex.html" :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 5, 2020, 10:43 AM UTC)_.

<details>
<summary>More</summary>



:link: [Related URL](https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fepub-3-wg-charter%2F6d0adbd1813d84c8960d8a80bbf1db4dd33b4265%2Findex.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-3-wg-charter%235.)._
</details>
