### PR TITLE
Possible new wording for #36

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
 				</ul>
 
 				<p>
-					EPUB 3.X will endeavor to remain compatible with existing content. <em>Any EPUB 3.2 publication should be valid under any new version of EPUB 3 published by this Working Group under this charter</em>, unless it relies on features discovered to have serious issues (e.g., related to security or an incorrect specification). In particular, all EPUB 3 specifications defined by this Working Group will use <code style="color:black">version=”3.0”</code> for the package file, to ensure compatibility with previous versions of EPUB 3.
+					The primary goal of EPUB 3.X is to remain compatible with existing content. <em>Any existing valid EPUB 3.2 should remain valid under EPUB 3.X,, unless it relies on features discovered to have serious issues (e.g., related to security).
 				</p>	
 
 				<p>
@@ -253,6 +253,7 @@
 						<li>Removal of any existing features defined by EPUB 3.2. Existing features will only be deprecated per existing practice.</li>
 						<li>DRM.</li>
 						<li>New serializations of the EPUB package file.</li>
+						<li>Changes to the package document version number. The number will remain "3.0" to ensure reading systems do not reject EPUB 3 files.</li>
 						<li>New packaging mechanisms for EPUB.</li>
 						<li>Any new elements, attributes, properties, or values that would create a fork from open web technologies (e.g., HTML, CSS or SVG).</li>
 						<li>Any new package document properties or values that influence rendering inside viewports that can be deferred to more appropriate working groups.</li>

--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
 				</p>
 
 				<p>
-					The Working Group will produce a new version of EPUB 3, codenamed “EPUB 3.X” for the purposes of this charter; the Working Group will have to define the correct numbering scheme (e.g., EPUB 3.2.1, or EPUB 3.3, etc.). The Working Group will <em>not</em> change the EPUB 3.2 itself. 
+					The Working Group will produce a new version of EPUB 3, codenamed “EPUB 3.X” for the purposes of this charter; the Working Group will have to define the correct numbering scheme (e.g., EPUB 3.2.1, or EPUB 3.3, etc.). The Working Group will <em>not</em> change the EPUB 3.2 specification itself. 
 				</p>
 
 				<p>
@@ -238,7 +238,7 @@
 				</ul>
 
 				<p>
-					The primary goal of EPUB 3.X is to remain compatible with existing content. <em>Any existing valid EPUB 3.2 should remain valid under EPUB 3.X,, unless it relies on features discovered to have serious issues (e.g., related to security).
+					The primary goal of EPUB 3.X is to remain compatible with existing content. <em>Any existing valid EPUB 3.2 should remain valid under EPUB 3.X, unless it relies on features discovered to have serious issues (such as a security bug).
 				</p>	
 
 				<p>


### PR DESCRIPTION
I am perhaps a bit out of my league with GitHub... I think this is a PR to update Ivan's open PR? But who knows? 

Anyway, based on some discussion in #36, here I:

1. Use Matt's wording for package version number attribute, and move it to the out-of-scope section

2. Propose some compromise language on the scope paragraph we've been discussing

3. Fix a random missing word elsewhere in the charter. 