### PR TITLE
Adding reference to the survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,10 +77,10 @@
 				padding:  0.5em;
 			}
 
-			body {	 
+			body {
 				background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 150 100' width='100%' height='50%' opacity='.06'> <g transform='translate(73,45) rotate(-40)'> <rect fill='none' stroke='red' stroke-width='2' width='120' x='-60' y='3' height='20' rx='10' ry='10'/> <text x='0' y='20' font-family='sans-serif' font-size='18' fill='red' text-anchor='middle'>Draft</text> </g> </svg>");
-				background-position: top center;	 
-				background-repeat: repeat;	 
+				background-position: top center;
+				background-repeat: repeat;
 			}
 
 		</style>
@@ -112,7 +112,7 @@
 			<div class=warning>
 				<h1>DRAFT</h1>
 				<p>
-					This is a <em>draft</em> text, under development by the community. The W3C Advisory Committee has been informed on the development this draft. 
+					This is a <em>draft</em> text, under development by the community. The W3C Advisory Committee has been informed on the development this draft.
 					The goal is to, eventually, submit this draft charter proposal to an official W3C AC review.
 				</p>
 				<p>
@@ -122,7 +122,7 @@
 					This proposed charter is available on <a href="https://github.com/w3c/epub-3-wg-charter">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/epub-3-wg-charter/issues">issues</a></i>.
 				</p>
 			</div>
-			  
+
 			<p class="mission">
 				The <strong>mission</strong> of the EPUB 3 Working Group is to maintain and develop the EPUB 3 family of specifications, to represent the EPUB community in the W3C, and to support EPUB 3 content creators and consumers by further advancing, refining, and clarifying the current EPUB 3 specification. The Working Group will also work closely with the Publishing Community Group to support the maintenance of validation tools and the creation of documentation.
 			</p>
@@ -163,7 +163,7 @@
 						<td>
 							Dave Cramer (Hachette Livre),
 							Wendy Reid (Rakuten Kobo),
-							Shinya Takami (高見真也), (Kadokawa/Bookwalker)
+							Shinya Takami (高見真也) (Kadokawa/Bookwalker)
 						</td>
 						</tr>
 					<tr>
@@ -191,23 +191,23 @@
 
       		<section id="scope" class="scope">
 				<h2>Scope</h2>
-				
+
 				<p>
-					EPUB is a distribution and interchange format for digital publications and documents that has been in global use by publishers and vendors for over a decade. The latest version of EPUB, <a href='https://www.w3.org/publishing/epub32/epub-spec.html'>EPUB 3.2</a>, has been published by the <a href='https://www.w3.org/community/epub3/'>W3C EPUB 3 Community Group</a> as a Final Specification. EPUB 3 is strongly related to, and reliant upon, W3C specifications: it provides a means of representing, packaging, and encoding structured and semantically enhanced Web content—including <a href="https://html.spec.whatwg.org/multipage/">HTML</a>, <a href="https://www.w3.org/Style/CSS/specs.en.html">CSS</a>, <a href="https://www.w3.org/TR/SVG11/">SVG</a>, <a href="https://www.w3.org/TR/MathML/">MathML</a> and other resources—for distribution in a single–file container. 
-				</p>
-					
-				<p>
-					However, the interoperability of EPUB 3 content, and the conformance of EPUB 3 reading systems, remain a serious issue. There is a need for a more rigorous and comprehensive testing of EPUB 3; this may also mean the need for a further clarification of the standard text itself. (See also the <a href="https://www.w3.org/blog/2020/03/listen-to-the-people-the-future-of-epub-and-new-directions-for-publishing-w3c/">separate blog</a> for more background.) The EPUB 3 Working Group will advance, refine, and clarify the EPUB 3 standard to ensure its relevance as digital publishing continues to evolve, and specify a comprehensive testing environment for EPUB 3. 
+					EPUB is a distribution and interchange format for digital publications and documents that has been in global use by publishers and vendors for over a decade. The latest version of EPUB, <a href='https://www.w3.org/publishing/epub32/epub-spec.html'>EPUB 3.2</a>, has been published by the <a href='https://www.w3.org/community/epub3/'>W3C EPUB 3 Community Group</a> as a Final Specification. EPUB 3 is strongly related to, and reliant upon, W3C specifications: it provides a means of representing, packaging, and encoding structured and semantically enhanced Web content—including <a href="https://html.spec.whatwg.org/multipage/">HTML</a>, <a href="https://www.w3.org/Style/CSS/specs.en.html">CSS</a>, <a href="https://www.w3.org/TR/SVG11/">SVG</a>, <a href="https://www.w3.org/TR/MathML/">MathML</a> and other resources—for distribution in a single–file container.
 				</p>
 
 				<p>
-					The Working Group will produce a new version of EPUB 3, codenamed “EPUB 3.X” for the purposes of this charter; the Working Group will have to define the correct numbering scheme (e.g., EPUB 3.2.1, or EPUB 3.3, etc.). The Working Group will <em>not</em> change the EPUB 3.2 specification itself. 
+					However, the interoperability of EPUB 3 content, and the conformance of EPUB 3 reading systems, remain a serious issue. There is a need for a more rigorous and comprehensive testing of EPUB 3; this may also mean the need for a further clarification of the standard text itself. These needs were reinforced and informed by the community in a survey Publishing@W3C sent out to the digital publishing community in February 2020. An overview of the results and link to the complete results can be found <a href="https://www.w3.org/blog/2020/05/publishingw3c-epub-survey-results/">here</a>. (See also the <a href="https://www.w3.org/blog/2020/03/listen-to-the-people-the-future-of-epub-and-new-directions-for-publishing-w3c/">separate blog</a> for more background.) The EPUB 3 Working Group will advance, refine, and clarify the EPUB 3 standard to ensure its relevance as digital publishing continues to evolve, and specify a comprehensive testing environment for EPUB 3. 
+				</p>
+
+				<p>
+					The Working Group will produce a new version of EPUB 3, codenamed “EPUB 3.X” for the purposes of this charter; the Working Group will have to define the correct numbering scheme (e.g., EPUB 3.2.1, or EPUB 3.3, etc.). The Working Group will <em>not</em> change the EPUB 3.2 specification itself.
 				</p>
 
 				<p>
 					The scope of the EPUB 3 Working Group includes the following:
 				</p>
-				
+
 				<ul>
 					<li>
 						Improvements and clarifications related to reading system conformance.
@@ -219,7 +219,7 @@
 						Clarifications to the current use of open Web technologies, such as supported JavaScript APIs and CSS modules.
 					</li>
 					<li>
-						Enhancements and improvements to internationalization of technologies defined for EPUB to ensure global usability. While the content of a digital publication (HTML, CSS, etc.) already have advanced internationalization features, an EPUB 3 publication also includes additional textual content like metadata, table of contents, etc., which must abide to all requirements of internationalization. 
+						Enhancements and improvements to internationalization of technologies defined for EPUB to ensure global usability. While the content of a digital publication (HTML, CSS, etc.) already have advanced internationalization features, an EPUB 3 publication also includes additional textual content like metadata, table of contents, etc., which must abide to all requirements of internationalization.
 					</li>
 					<li>
 						Continued integration of errata and bug fixes.
@@ -254,11 +254,11 @@
 
 				<p>
 					The primary goal of EPUB 3.X is to remain compatible with existing content. <em>Any existing valid EPUB 3.2 should remain valid under EPUB 3.X, unless it relies on features discovered to have serious issues (such as a security bug).</em>
-				</p>	
+				</p>
 
 				<p>
 					The Working Group will also work with other groups, as appropriate, in the development of standards for digital publishing (e.g., an update to the <a href='https://www.w3.org/TR/dpub-aria-1.0/'>Digital Publishing WAI-ARIA Module</a>).
-				</p>					
+				</p>
 
 				<section id="section-out-of-scope">
 					<h3 id="out-of-scope">Out of Scope</h3>
@@ -299,7 +299,7 @@
             			<dt id="epub3" class="spec">EPUB 3.X</dt>
 						<dd>
               				<p>
-								EPUB 3 defines a distribution and interchange format for digital publications and documents. The EPUB format provides a means of representing, packaging and encoding structured and semantically enhanced Web content—including HTML, CSS, SVG and other resources—for distribution in a single-file container. 
+								EPUB 3 defines a distribution and interchange format for digital publications and documents. The EPUB format provides a means of representing, packaging and encoding structured and semantically enhanced Web content—including HTML, CSS, SVG and other resources—for distribution in a single-file container.
 							</p>
 							<p>
 								EPUB 3 is modular in nature: it consists of a family of specifications that define the core features and functionality of the standard. This specification represents the primary entry point to standard, but the specifications listed in this section are all a part of EPUB 3.
@@ -308,7 +308,7 @@
 							<p class="draft-status">
 								<b>Draft state:</b> <a href="https://www.w3.org/publishing/epub32/epub-spec.html">Final Community Group Specification</a>.
 							</p>
-								
+
 							<p class="milestone"><b>Expected completion:</b> Q1 2023</p>
 						</dd>
 
@@ -324,7 +324,7 @@
 							<p class="draft-status">
 								<b>Draft state:</b> <a href="https://www.w3.org/publishing/epub32/epub-packages.html">Final Community Group Specification</a>.
 							</p>
-								
+
 							<p class="milestone"><b>Expected completion:</b> Q1 2023</p>
 						</dd>
 
@@ -337,7 +337,7 @@
 							<p class="draft-status">
 								<b>Draft state:</b> <a href="https://www.w3.org/publishing/epub32/epub-contentdocs.html">Final Community Group Specification</a>.
 							</p>
-								
+
 							<p class="milestone"><b>Expected completion:</b> Q1 2023</p>
 						</dd>
 
@@ -350,7 +350,7 @@
 							<p class="draft-status">
 								<b>Draft state:</b> <a href="https://www.w3.org/publishing/epub32/epub-ocf.html">Final Community Group Specification</a>.
 							</p>
-								
+
 							<p class="milestone"><b>Expected completion:</b> Q1 2023</p>
 						</dd>
 
@@ -363,7 +363,7 @@
 							<p class="draft-status">
 								<b>Draft state:</b> <a href="https://www.w3.org/publishing/epub32/epub-mediaoverlays.html">Final Community Group Specification</a>.
 							</p>
-								
+
 							<p class="milestone"><b>Expected completion:</b> Q1 2023</p>
 						</dd>
 
@@ -376,7 +376,7 @@
 							<p class="draft-status">
 								<b>Draft state:</b> <a href="https://www.w3.org/Submission/2017/SUBM-epub-a11y-20170125/">W3C Member Submission</a>.
 							</p>
-								
+
 							<p class="milestone"><b>Expected completion:</b> Q1 2023</p>
 						</dd>
           			</dl>
@@ -401,7 +401,7 @@
 						</li>
 					</ul>
 					<p>
-						Furthermore, the Working group will review the existing EPUB registries, originally published by <a href='http://idpf.org'><abbr title="International Digital Publishing Forum">IDPF</abbr></a> and, if necessary, will set up a long term control at W3C for their maintenance. These registries include: 
+						Furthermore, the Working group will review the existing EPUB registries, originally published by <a href='http://idpf.org'><abbr title="International Digital Publishing Forum">IDPF</abbr></a> and, if necessary, will set up a long term control at W3C for their maintenance. These registries include:
 					</p>
 					<ul>
 						<li><a href='http://www.idpf.org/epub/registries/authorities/'>EPUB Subject Authorities Registry</a>.</li>
@@ -429,18 +429,18 @@
 
 			<section id="success-criteria">
 				<h2>Success Criteria</h2>
-				
-				<p>The EPUB 3 Working Group’s work is considered a success 
+
+				<p>The EPUB 3 Working Group’s work is considered a success
 				if:</p>
-				
+
 				<ol>
-					<li>There are multiple, independent, interoperable implementations 
+					<li>There are multiple, independent, interoperable implementations
 					of EPUB 3.X that are widely used.</li>
 					<li>Existing content is supported. All conforming EPUB 3.2 publications should remain conformant to EPUB 3.X.</li>
-					<li>Improvements to the standard solve immediate and quantifiable issues faced in the EPUB ecosystem.</li>					
-					<li>Changes that affect the global ecosystem 
-					(including authors, publishers, distributors, retailers, reading systems, and tool makers) 
-					are minimized, and made only after careful consideration 
+					<li>Improvements to the standard solve immediate and quantifiable issues faced in the EPUB ecosystem.</li>
+					<li>Changes that affect the global ecosystem
+					(including authors, publishers, distributors, retailers, reading systems, and tool makers)
+					are minimized, and made only after careful consideration
 					of how they would affect all constituencies.</li>
 					<li>Validation tools such as EPUBCheck fully support EPUB 3.X.</li>
 				</ol>
@@ -503,7 +503,7 @@
 						<dt><a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a></dt>
 						<dd>
 							<p>
-								The Accessibility Guidelines Working Group develops guidelines to make Web content accessible for people with disabilities, and is responsible for the development and maintenance of the WCAG series of Recommendations. The EPUB Accessibility specification is already based on WCAG, and a liaison will be set up to ensure that any new features in EPUB 3.X, in particular EPUB Accessibility 1.X, would continue to refer to WCAG 2.X, when applicable.    
+								The Accessibility Guidelines Working Group develops guidelines to make Web content accessible for people with disabilities, and is responsible for the development and maintenance of the WCAG series of Recommendations. The EPUB Accessibility specification is already based on WCAG, and a liaison will be set up to ensure that any new features in EPUB 3.X, in particular EPUB Accessibility 1.X, would continue to refer to WCAG 2.X, when applicable.
 							</p>
 						</dd>
 						<dt><a href="https://www.w3.org/WAI/ARIA/">ARIA Working Group</a></dt>
@@ -522,7 +522,7 @@
 						<dt><a href='https://www.w3.org/Graphics/SVG/'>SVG Working Group</a></dt>
 						<dd>
 							<p>
-								The SVG Working Group is responsible for the development of <a href='https://www.w3.org/TR/SVG11/'>SVG</a>. This development may have an influence on the future evolution of EPUB 3. Also, new technical features arising during the development of EPUB 3.X may lead to new feature requirements for SVG, in which case these should be explored further together with the SVG Working Group (and the <a href='https://www.w3.org/community/svgcg/'>SVG CG</a>).  
+								The SVG Working Group is responsible for the development of <a href='https://www.w3.org/TR/SVG11/'>SVG</a>. This development may have an influence on the future evolution of EPUB 3. Also, new technical features arising during the development of EPUB 3.X may lead to new feature requirements for SVG, in which case these should be explored further together with the SVG Working Group (and the <a href='https://www.w3.org/community/svgcg/'>SVG CG</a>).
 							</p>
 						</dd>
 
@@ -542,7 +542,7 @@
 						<dd>
 							<p>
 								The Readium projects (Readium Mobile, Readium Desktop, and Readium Web) are at the core of a number of EPUB 3 reading systems around the world. As such, the feedback of that development will be essential to the work around EPUB 3.X.
-							</p>							
+							</p>
 						</dd>
 						<dt><a href="https://www.edrlab.org/">EDRLab</a></dt>
 						<dd>
@@ -554,8 +554,8 @@
 						<dt><a href="https://daisy.org/">DAISY Consortium</a></dt>
 						<dd>
 							<p>
-								The DAISY consortium currently manages <a href="http://epubtest.org/">epubtest.org</a>, 
-								the support grid for EPUB. They also provide support on specification writing, accessibility, 
+								The DAISY consortium currently manages <a href="http://epubtest.org/">epubtest.org</a>,
+								the support grid for EPUB. They also provide support on specification writing, accessibility,
 								and feedback on EPUB implementation. Their feedback on the further development of EPUB in general, and EPUB Accessibility in particular, will be essential for the EPUB 3.X development.
 							</p>
 						</dd>
@@ -570,7 +570,7 @@
 						<dt><a href="https://whatwg.org">WHATWG</a></dt>
 						<dd>
 							<p>
-								The WHATWG is responsible for the development of <a href='https://html.spec.whatwg.org/multipage/'>HTML</a>. This may have an influence on the future evolution of EPUB 3. Also, new technical features arising during the development of EPUB 3.X may lead to new feature requirements for HTML, in which case these should be explored further together with the WHATWG (and the <a href='https://www.w3.org/community/wicg/'>WICG</a>).  
+								The WHATWG is responsible for the development of <a href='https://html.spec.whatwg.org/multipage/'>HTML</a>. This may have an influence on the future evolution of EPUB 3. Also, new technical features arising during the development of EPUB 3.X may lead to new feature requirements for HTML, in which case these should be explored further together with the WHATWG (and the <a href='https://www.w3.org/community/wicg/'>WICG</a>).
 							</p>
 						</dd>
 
@@ -580,7 +580,7 @@
 								An earlier version of EPUB (<a href="http://idpf.org/epub/301">EPUB 3.0.1</a>) was published as an ISO standard ISO/IEC TS 30135:2014 (parts 1-7). This Working Group and ISO may consider updating that ISO specification once the new Recommendations are published.
 							</p>
 							<p>
-								Additionally, there are currently activities within <a href="https://isotc.iso.org/livelink/livelink?func=ll&objId=8913149&objAction=browse&sort=name">ISO/IEC JTC 001/SC34</a> on specifications that rely on earlier versions of EPUB (e.g., EPUB Preservation, EPUB Accessibility). A liaison has to be maintained on, possibly, updating those ISO specifications to the latest versions of EPUB 3, specified by this Working Group. 
+								Additionally, there are currently activities within <a href="https://isotc.iso.org/livelink/livelink?func=ll&objId=8913149&objAction=browse&sort=name">ISO/IEC JTC 001/SC34</a> on specifications that rely on earlier versions of EPUB (e.g., EPUB Preservation, EPUB Accessibility). A liaison has to be maintained on, possibly, updating those ISO specifications to the latest versions of EPUB 3, specified by this Working Group.
 							</p>
 						</dd>
 
@@ -643,7 +643,7 @@
 				Decision Policy
 				</h2>
 				<p>
-					This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+					This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
 				<p>
 					However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
 				</p>


### PR DESCRIPTION
Adding a reference to the EPUB survey completed in February, including a link to the overview and results, as requested in Issue #45


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-3-wg-charter/pull/50.html" title="Last updated on May 29, 2020, 2:44 PM UTC (5716db3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-3-wg-charter/50/023970b...5716db3.html" title="Last updated on May 29, 2020, 2:44 PM UTC (5716db3)">Diff</a>