### PR TITLE
Editorial changes on A11y

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
 						Improvements of the <a href='#a11y'>EPUB Accessibility</a> specification; these may include, but not limited to:
 						<ul>
 							<li>
-								verify that EPUB Accessibility 1.X meets the <a href='https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2019.151.01.0070.01.ENG&toc=OJ:L:2019:151:TOC'>EU Directive for accessibility requirements for eBooks</a> (European Accessibility Act, Directive 2019/882 of the European Parliament); the WG will conduct a review of the <a href='#a11y'>EPUB Accessibility</a> specification for meeting the EU requirements, provide clarifications, and add the missing pieces if required;
+								verify that EPUB Accessibility 1.X aligns with the <a href='https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2019.151.01.0070.01.ENG&toc=OJ:L:2019:151:TOC'>EU Directive for accessibility requirements for eBooks</a> (European Accessibility Act, Directive 2019/882 of the European Parliament) to the extent possible; the WG will conduct a review of the <a href='#a11y'>EPUB Accessibility</a> specification to ensure that it aligns with the EU accessible publishing requirements to the extent that these improve accessibility;
 							</li>
 							<li>
 								consider new and incremental features on accessibility, provided that the aforementioned EU accessibility requirements and the underlying WCAG 2.X requirements are not compromised; the features under consideration include accessibility requirements for fixed layout documents (FXL), or the possibility of referring to different versions of WCAG 2.X;


### PR DESCRIPTION
Following the proposals by @brewerj in https://github.com/w3c/epub-3-wg-charter/issues/42#issuecomment-641064373

Fix #42


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-3-wg-charter/pull/53.html" title="Last updated on Jun 9, 2020, 10:40 AM UTC (cecf149)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-3-wg-charter/53/fc8babe...cecf149.html" title="Last updated on Jun 9, 2020, 10:40 AM UTC (cecf149)">Diff</a>