### PR TITLE
Update charter language based on AC Review

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,14 +448,14 @@
 					Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.
 				</p>
 				<p>
-					There should be testing plans for each specification, starting from the earliest drafts.
+					There must be testing plans for each specification, starting from the earliest drafts.
 				</p>
 				<p>
 					Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 					recommendations for maximizing accessibility in implementations.
 				</p>
 				<p>
-					To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.
+					To promote interoperability, all changes made to specifications must have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.
 				</p>
 			</section>
 

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
 					Any text rendered like <span class=todo>this</span> refer to content that must be updated when the final charter is published at the latest (e.g., adjusting hyperlinks).
 				</p>
 				<p>
-					This proposed charter is available on <a href="https://github.com/w3c/epub-3-wg-charter">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/epub-3-wg-charter/issues">issues</a></i>.
+					This proposed charter is available on <a href="https://github.com/w3c/epub-3-wg-charter">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/epub-3-wg-charter/issues">issues</a>.
 				</p>
 			</div>
 
@@ -262,7 +262,9 @@
 					<p>The following features are out of scope, and will not be addressed by this Working Group group.</p>
 
 					<ul>
-						<li>Removal of any existing features defined by EPUB 3.2. Existing features will only be deprecated if they are not used by <a href="https://www.w3.org/TR/html-design-principles/#support-existing-content">existing EPUB 3 content</a> or unsupported by existing EPUB 3 reading systems.</li>
+						<li>Removal of any existing features defined by EPUB 3.2. 
+						Existing features will only be deprecated if they are not needed 
+						to support existing EPUB 3 content, as stated in <a href="https://www.w3.org/TR/html-design-principles/#support-existing-content">HTML’s design principles</a>.</li>
 						<li>Digital Rights Management (DRM).</li>
 						<li>New serialization format for the <a href='https://www.w3.org/publishing/epub32/epub-packages.html#sec-package-doc'>EPUB Package Document</a>.</li>
 						<li>Changes to the EPUB Package Document <a href='https://www.w3.org/publishing/epub32/epub-packages.html#sec-package-elem'>version number</a>. The number will remain "3.0" to ensure reading systems do not reject EPUB 3 files.</li>

--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
 					<p>The following features are out of scope, and will not be addressed by this Working Group group.</p>
 
 					<ul>
-						<li>Removal of any existing features defined by EPUB 3.2. Existing features will only be deprecated per existing practice.</li>
+						<li>Removal of any existing features defined by EPUB 3.2. Existing features will only be deprecated if they are not used by <a href="https://www.w3.org/TR/html-design-principles/#support-existing-content">existing EPUB 3 content</a> or unsupported by existing EPUB 3 reading systems.</li>
 						<li>Digital Rights Management (DRM).</li>
 						<li>New serialization format for the <a href='https://www.w3.org/publishing/epub32/epub-packages.html#sec-package-doc'>EPUB Package Document</a>.</li>
 						<li>Changes to the EPUB Package Document <a href='https://www.w3.org/publishing/epub32/epub-packages.html#sec-package-elem'>version number</a>. The number will remain "3.0" to ensure reading systems do not reject EPUB 3 files.</li>


### PR DESCRIPTION
This PR does two things:

1. Changes "should" to "must" around some testing requirements.

2. The current charter says,

> Existing features will only be deprecated per existing practice.

This tries to briefly describe what that existing practice is, as it doesn't appear to be well-documented elsewhere.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dauwhe/epub-3-wg-charter/pull/60.html" title="Last updated on Jul 27, 2020, 5:34 PM UTC (5e4723f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-3-wg-charter/60/1e6fb37...dauwhe:5e4723f.html" title="Last updated on Jul 27, 2020, 5:34 PM UTC (5e4723f)">Diff</a>